### PR TITLE
Allow multiple php-fpm sessions

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -29,6 +29,8 @@ services:
   php-fpm:
     build:
       context: ./php-fpm
+    ports:
+      - "9000:9000"      
     volumes:
       - ../web-root:/var/www
     user: www-root

--- a/docker-compose/php-fpm/Dockerfile
+++ b/docker-compose/php-fpm/Dockerfile
@@ -3,6 +3,3 @@ FROM php:fpm-alpine
 RUN docker-php-ext-install mysqli 
 
 CMD ["php-fpm"]
-
-EXPOSE 9000
-


### PR DESCRIPTION
Move port exposure into the docker-compose file so if consumers want, they can start multiple isolated php-fpm sessions by just copying the php-fpm section.